### PR TITLE
daxfs: Fix truncate not updating VFS i_size in setattr

### DIFF
--- a/daxfs/file.c
+++ b/daxfs/file.c
@@ -465,6 +465,14 @@ static int daxfs_setattr(struct mnt_idmap *idmap, struct dentry *dentry,
 			return ret;
 	}
 
+	/*
+	 * setattr_copy() does not handle ATTR_SIZE — the filesystem
+	 * must update i_size itself.  Use truncate_setsize() which
+	 * also invalidates any stale pagecache above the new size.
+	 */
+	if (attr->ia_valid & ATTR_SIZE)
+		truncate_setsize(inode, attr->ia_size);
+
 	setattr_copy(idmap, inode, attr);
 	return 0;
 }


### PR DESCRIPTION
daxfs_setattr() relied on setattr_copy() to update i_size when handling ATTR_SIZE (e.g. O_TRUNC). However, setattr_copy() does not handle ATTR_SIZE — the filesystem must update i_size itself.

This caused a bug where overwriting an existing file via shell redirect (echo "..." > file) would produce empty reads:

1. O_TRUNC triggers setattr(ATTR_SIZE=0) which creates an overlay inode entry with size=0, but VFS i_size stays at the original base image size (e.g. 23 bytes)
2. The subsequent write (21 bytes) sees pos(21) <= i_size(23), so the "update size if extending" check is skipped — the overlay inode size is never updated from 0
3. On read, daxfs_refresh_isize() reads overlay size=0 and clobbers VFS i_size to 0, causing the read to return empty

Fix by calling truncate_setsize() before setattr_copy() when ATTR_SIZE is set. This is the standard pattern used by other Linux filesystems (ramfs, tmpfs, etc.).

Fixes: #8 