### PR TITLE
daxfs: Fix superblock and inode geometry reported to the VFS

### DIFF
--- a/daxfs/daxfs.h
+++ b/daxfs/daxfs.h
@@ -146,6 +146,16 @@ extern void *daxfs_base_file_data(struct daxfs_info *info,
 				  loff_t pos, size_t len, size_t *out_len,
 				  s32 *pinned_slot);
 
+/*
+ * Keep i_blocks in sync with i_size. daxfs has no block allocator, but
+ * stat() consumers treat st_blocks == 0 as a fully sparse file: swapon(8)
+ * refuses such a file outright, and du/tar/rsync misreport it.
+ */
+static inline void daxfs_update_blocks(struct inode *inode)
+{
+	inode->i_blocks = (i_size_read(inode) + 511) >> 9;
+}
+
 /* inode.c */
 extern struct inode *daxfs_alloc_inode(struct super_block *sb);
 extern void daxfs_free_inode(struct inode *inode);

--- a/daxfs/file.c
+++ b/daxfs/file.c
@@ -344,23 +344,24 @@ static ssize_t daxfs_write_iter(struct kiocb *iocb, struct iov_iter *from)
 	struct inode *inode = file_inode(iocb->ki_filp);
 	struct daxfs_info *info = DAXFS_SB(inode->i_sb);
 	loff_t pos;
-	size_t len = iov_iter_count(from);
+	size_t len;
 	size_t total = 0;
+	ssize_t ret;
 
 	if (!info->overlay)
 		return -EROFS;
 
-	if (len == 0)
-		return 0;
-
 	/*
-	 * O_APPEND: the write must land at the current end of file. The
-	 * VFS leaves IOCB_APPEND positioning to the filesystem's write_iter,
-	 * so without this an append-mode fd writes at its stale ki_pos
-	 * (0 on a freshly opened fd), corrupting the file.
+	 * Enforces s_maxbytes, RLIMIT_FSIZE and O_LARGEFILE. It also performs
+	 * the O_APPEND repositioning that the VFS leaves to ->write_iter,
+	 * without which an append-mode fd writes at its stale ki_pos (0 on a
+	 * freshly opened fd), corrupting the file.
 	 */
-	if (iocb->ki_flags & IOCB_APPEND)
-		iocb->ki_pos = i_size_read(inode);
+	ret = generic_write_checks(iocb, from);
+	if (ret <= 0)
+		return ret;
+
+	len = ret;
 	pos = iocb->ki_pos;
 
 	/* Batch-preallocate overlay pages for multi-page writes */

--- a/daxfs/file.c
+++ b/daxfs/file.c
@@ -30,8 +30,10 @@ static void daxfs_refresh_isize(struct inode *inode, struct daxfs_info *info)
 	if (oie) {
 		loff_t ovl_size = le64_to_cpu(READ_ONCE(oie->size));
 
-		if (ovl_size != inode->i_size)
+		if (ovl_size != inode->i_size) {
 			i_size_write(inode, ovl_size);
+			daxfs_update_blocks(inode);
+		}
 	}
 }
 
@@ -434,6 +436,7 @@ static ssize_t daxfs_write_iter(struct kiocb *iocb, struct iov_iter *from)
 		struct daxfs_ovl_inode_entry *oie;
 
 		inode->i_size = pos;
+		daxfs_update_blocks(inode);
 		oie = daxfs_overlay_get_inode(info, inode->i_ino);
 		if (oie) {
 			/*
@@ -512,8 +515,10 @@ static int daxfs_setattr(struct mnt_idmap *idmap, struct dentry *dentry,
 	 * must update i_size itself.  Use truncate_setsize() which
 	 * also invalidates any stale pagecache above the new size.
 	 */
-	if (attr->ia_valid & ATTR_SIZE)
+	if (attr->ia_valid & ATTR_SIZE) {
 		truncate_setsize(inode, attr->ia_size);
+		daxfs_update_blocks(inode);
+	}
 
 	setattr_copy(idmap, inode, attr);
 	return 0;

--- a/daxfs/inode.c
+++ b/daxfs/inode.c
@@ -103,6 +103,7 @@ found:
 	inode->i_uid = make_kuid(&init_user_ns, uid);
 	inode->i_gid = make_kgid(&init_user_ns, gid);
 	inode->i_size = size;
+	daxfs_update_blocks(inode);
 	set_nlink(inode, nlink);
 
 	inode_set_mtime_to_ts(inode,

--- a/daxfs/super.c
+++ b/daxfs/super.c
@@ -193,6 +193,15 @@ static int daxfs_fill_super(struct super_block *sb, struct fs_context *fc)
 		goto err_unmap;
 	}
 
+	/*
+	 * Left unset, s_blocksize_bits stays 0, every inode inherits
+	 * i_blkbits == 0, and stat() reports st_blksize == 1. Tools that size
+	 * their I/O buffer from st_blksize (cp, tar, stdio) then fall back to
+	 * one byte per syscall.
+	 */
+	sb->s_blocksize = info->block_size;
+	sb->s_blocksize_bits = ilog2(info->block_size);
+
 	/* Validate overall image structure bounds (if requested) */
 	if (ctx->validate) {
 		ret = daxfs_validate_super(info);

--- a/daxfs/super.c
+++ b/daxfs/super.c
@@ -159,6 +159,15 @@ static int daxfs_fill_super(struct super_block *sb, struct fs_context *fc)
 	info->sb = sb;
 	sb->s_time_gran = 1;
 
+	/*
+	 * The alloc_super() default is MAX_NON_LFS (2 GiB), which caps llseek
+	 * and writes far below what a base image can hold; shared model
+	 * weights are routinely larger. Writable files have a tighter ceiling
+	 * from the overlay's 20-bit page offset, but that is per-inode and
+	 * enforced where pages are allocated, not here.
+	 */
+	sb->s_maxbytes = MAX_LFS_FILESIZE;
+
 	if (ctx->backing_path && ctx->export_path) {
 		pr_err("daxfs: 'backing' and 'export' are mutually exclusive\n");
 		ret = -EINVAL;


### PR DESCRIPTION
## Problem

Reported as #13.  Tracing that turned up three pieces of superblock/inode geometry that `daxfs_fill_super()` and `daxfs_iget()` never filled in, leaving the VFS to work from `alloc_super()` defaults of zero.

**`s_blocksize` was never set.** `s_blocksize`/`s_blocksize_bits` stayed 0, so every inode inherited `i_blkbits == 0` and `stat()` reported `st_blksize == 1`. Any tool that sizes its I/O buffer from `st_blksize` (`cp`, `tar`, stdio, Python's `io`) then moves **one byte per syscall**. On a multi-gigabyte file that is indistinguishable from a hang, and it lands squarely on the step before `swapon` in every swapfile recipe.

**`i_blocks` was never set.** `daxfs_iget()` populated `i_size` but not `i_blocks`, so `st_blocks` was always 0. Consumers read that as a fully sparse file. util-linux `swapon(8)` refuses outright:

```
swapon: /mnt/daxfs/swapfile: skipping - it appears to have holes.
```

...before it ever reaches the syscall. `du`/`tar`/`rsync` misreport usage for the same reason.

**`s_maxbytes` was left at `MAX_NON_LFS`**, capping the filesystem at 2 GiB - 1. That is far below what a base image can hold; the shared model weight files daxfs exists to serve are routinely much larger. `llseek()` past 2 GiB returned `-EINVAL` on files daxfs could otherwise read fine. `daxfs_write_iter()` also never called `generic_write_checks()`, so it enforced neither `s_maxbytes` nor `RLIMIT_FSIZE` nor `O_LARGEFILE`, and let `i_size` grow past what the VFS considers representable.

## Fix

**Block size.** Derived from the image's `block_size` rather than from `PAGE_SIZE` directly. The two are equal today because `fill_super` rejects any image whose `block_size` differs from the native page size, but deriving keeps `s_blocksize` correct if that constraint is ever relaxed for hosts with differing page sizes. The assignment sits after the `block_size` parse and before the root inode is created, so nothing observes a zero `s_blocksize_bits`. `daxfs_statfs()` already reported `f_bsize = info->block_size`, so all three now agree.

**`i_blocks`.** Kept in sync via one helper called at every site that writes `i_size`: `daxfs_iget()`, `daxfs_refresh_isize()`, `daxfs_write_iter()` write-extend, and `daxfs_setattr()` truncate. `daxfs_getattr()` already calls `daxfs_refresh_isize()` before `generic_fillattr()`, so `stat` picks both up.

**`s_maxbytes`.** Set to `MAX_LFS_FILESIZE`, with writes routed through `generic_write_checks()`. Writable files have a tighter ceiling from the overlay's 20-bit page offset (`DAXFS_OVL_MAX_PGOFF`, so `0xFFFFE << PAGE_SHIFT`), but that is per-inode and stays enforced where pages are allocated; using it as `s_maxbytes` would wrongly cap read-only base images, which have no such limit. `generic_write_checks()` also performs the O_APPEND repositioning that commit abcdc5b added by hand, so the open-coded version is dropped, and it rejects writes to an active swapfile and unsupported `IOCB_NOWAIT`.

## Not addressed here

**Swap still does not work.** `daxfs_aops` is empty, so `swapon(2)` returns `-EINVAL` at the `!mapping->a_ops->read_folio` check in `SYSCALL_DEFINE2(swapon)` regardless of these changes. What improves is that `swapon(8)` now reaches the syscall and reports the real error instead of being turned away earlier for the wrong reason. Making swap function needs `->swap_activate`/`->swap_deactivate`/`->swap_rw`. Note `ext4_dax_aops` has no `->read_folio` either, so rejecting swapfiles is consistent with how DAX filesystems behave generally.

## Testing

Module builds clean against 7.0.11 headers with no new warnings. No existing test reads `st_blocks` or `st_blksize` (`tests/test_overlay.sh` uses only `stat -c %s`).

Not verified at runtime: mounting daxfs needs root and a DAX region/dma-heap. On a DAX host:

```bash
stat -c 'blocks=%b size=%s io=%o' /mnt/daxfs/somefile
```

Before: `io=1`, `blocks=0`. After: `io=4096` (native page size), `blocks` = size rounded up to 512-byte units. Once `blocks*512 >= size`, `swapon(8)` stops rejecting the file as sparse. For `s_maxbytes`, a seek past 2 GiB on a large base-image file should now succeed rather than returning `EINVAL`.
