### PR TITLE
daxfs: Skip the hardened usercopy check on region copies

### DIFF
--- a/daxfs/dax_mem.c
+++ b/daxfs/dax_mem.c
@@ -12,6 +12,7 @@
 #include <linux/slab.h>
 #include <linux/dma-buf.h>
 #include <linux/mm.h>
+#include <linux/uio.h>
 #include "daxfs.h"
 
 /**
@@ -111,6 +112,54 @@ void *daxfs_mem_ptr(struct daxfs_info *info, u64 offset)
 	if (offset >= info->size)
 		return NULL;
 	return info->mem + offset;
+}
+
+/* Is [ptr, ptr+len) entirely inside the mapped DAX region? */
+static bool daxfs_in_region(struct daxfs_info *info, void *ptr, size_t len)
+{
+	size_t off;
+
+	if (!info->mem || ptr < info->mem)
+		return false;
+
+	off = (char *)ptr - (char *)info->mem;
+	if (off > info->size)
+		return false;
+
+	return len <= info->size - off;
+}
+
+/*
+ * Copy between the DAX region and userspace.
+ *
+ * copy_to_iter() runs hardened usercopy's check_heap_object() on the source,
+ * and for a vmalloc address that means find_vmap_area(): a vmap node spinlock
+ * per call, plus a walk backwards across nodes because one vmap_area spans
+ * the whole region while addr_to_node_id() changes every vmap_zone_size
+ * bytes. Every backend lands there except memremap() over system RAM
+ * (dma_buf_vmap() vmaps, and memremap() falls back to ioremap() for memory
+ * the kernel does not own, which is the multikernel spawn case).
+ *
+ * Bypass the check as drivers/dax/super.c does, after bounds-checking the
+ * range ourselves. The userspace side is already validated by access_ok()
+ * in the vfs read/write path.
+ */
+size_t daxfs_copy_to_iter(struct daxfs_info *info, void *src, size_t len,
+			  struct iov_iter *to)
+{
+	if (WARN_ON_ONCE(!daxfs_in_region(info, src, len)))
+		return 0;
+
+	return _copy_to_iter(src, len, to);
+}
+
+size_t daxfs_copy_from_iter(struct daxfs_info *info, void *dst, size_t len,
+			    struct iov_iter *from)
+{
+	if (WARN_ON_ONCE(!daxfs_in_region(info, dst, len)))
+		return 0;
+
+	return _copy_from_iter(dst, len, from);
 }
 
 /**

--- a/daxfs/daxfs.h
+++ b/daxfs/daxfs.h
@@ -167,6 +167,10 @@ extern void daxfs_mem_exit(struct daxfs_info *info);
 
 /* Pointer/offset conversion */
 extern void *daxfs_mem_ptr(struct daxfs_info *info, u64 offset);
+extern size_t daxfs_copy_to_iter(struct daxfs_info *info, void *src,
+				 size_t len, struct iov_iter *to);
+extern size_t daxfs_copy_from_iter(struct daxfs_info *info, void *dst,
+				   size_t len, struct iov_iter *from);
 extern u64 daxfs_mem_offset(struct daxfs_info *info, void *ptr);
 extern phys_addr_t daxfs_mem_phys(struct daxfs_info *info, u64 offset);
 

--- a/daxfs/file.c
+++ b/daxfs/file.c
@@ -138,9 +138,23 @@ void *daxfs_base_file_data(struct daxfs_info *info,
 		return page + intra;
 	}
 
-	return daxfs_mem_ptr(info,
-			     le64_to_cpu(info->super->base_offset) +
-			     data_offset + pos);
+	/*
+	 * Bound the run against the mapped region, not just its start: the
+	 * caller copies *out_len bytes from this pointer, and a truncated or
+	 * malformed image can put data_offset+size past the end.
+	 */
+	{
+		u64 off = le64_to_cpu(info->super->base_offset) +
+			  data_offset + pos;
+
+		if (off >= info->size)
+			return NULL;
+		if (len > info->size - off)
+			len = info->size - off;
+		if (out_len)
+			*out_len = len;
+		return info->mem + off;
+	}
 }
 
 /*
@@ -217,8 +231,8 @@ static ssize_t daxfs_read_iter(struct kiocb *iocb, struct iov_iter *to)
 						      (size_t)PAGE_SIZE);
 				}
 
-				if (copy_to_iter(page + intra, contig,
-						 to) != contig)
+				if (daxfs_copy_to_iter(info, page + intra,
+						       contig, to) != contig)
 					return total ? total : -EFAULT;
 
 				pos += contig;
@@ -235,7 +249,7 @@ static ssize_t daxfs_read_iter(struct kiocb *iocb, struct iov_iter *to)
 			break;
 		}
 
-		if (copy_to_iter(src, chunk, to) != chunk) {
+		if (daxfs_copy_to_iter(info, src, chunk, to) != chunk) {
 			daxfs_pcache_put_page(info, pcslot);
 			return total ? total : -EFAULT;
 		}
@@ -421,7 +435,8 @@ static ssize_t daxfs_write_iter(struct kiocb *iocb, struct iov_iter *from)
 				 GFP_KERNEL);
 		}
 
-		if (copy_from_iter(page + intra, chunk, from) != chunk)
+		if (daxfs_copy_from_iter(info, page + intra, chunk,
+					 from) != chunk)
 			return total ? total : -EFAULT;
 
 		pos += chunk;


### PR DESCRIPTION
## Problem

Buffered reads on daxfs do not scale. Throughput is flat from 1 to 16 threads while mean latency rises in proportion to the thread count, which is the signature of a serialization point rather than saturated bandwidth. A 64 MiB file small enough to sit in cache behaves identically, ruling out memory bandwidth and TLB pressure.

`perf record` during an 8-job `psync` random read put 82% of all cycles in lock contention:

```
   48.99%  _raw_spin_lock
   32.93%  native_queued_spin_lock_slowpath
    5.47%  _copy_to_iter
    5.40%  find_vmap_area
```

```
native_queued_spin_lock_slowpath+0x2c4
_raw_spin_lock+0x2d
find_vmap_area+0x62
__check_object_size+0x1d4          <- CONFIG_HARDENED_USERCOPY
daxfs_read_iter
vfs_read+0x20d  ->  ksys_pread64  ->  entry_SYSCALL_64
```

Only 5.5% of the time was spent moving bytes.

## Why it degrades so badly

With `CONFIG_HARDENED_USERCOPY` every `copy_to_iter()` out of the region reaches `check_heap_object()`, and for a vmalloc address that calls `find_vmap_area()`:

```c
i = j = addr_to_node_id(addr);        /* (addr / vmap_zone_size) % nr_vmap_nodes */
do {
	vn = &vmap_nodes[i];
	spin_lock(&vn->busy.lock);
	va = __find_vmap_area(addr, &vn->busy.root);
	spin_unlock(&vn->busy.lock);
	if (va) return va;
} while ((i = (i + nr_vmap_nodes - 1) % nr_vmap_nodes) != j);
```

The per-node vmap tree does not help. One `vmap_area` spans the entire mapping and is filed in the single node derived from its `va_start`, while `addr_to_node_id()` changes every `vmap_zone_size` bytes (16 pages). A lookup for an address outside the owning node misses and keeps locking its way backwards node by node until it reaches the owner.

`nr_vmap_nodes` is `clamp(num_possible_cpus(), 1, 128)`, so on the 40 CPU test host a single 4 KiB `pread()` can take up to 40 lock round trips on shared cache lines, with every CPU converging on the same owning node. The cost is present even single-threaded and worsens with core count.

**This is not only the dma-buf case.** `memremap()` returns a direct-map pointer only when `region_intersects()` reports `IORESOURCE_SYSTEM_RAM` and `pfn_valid()` holds; otherwise it falls back to `ioremap_cache()`, which also returns a vmalloc-range address. A multikernel spawn kernel mounting a shared region carved out of its own memory map satisfies neither condition, so it takes the slow path too.

## Fix

Use the unchecked `iov_iter` helpers and bounds-check the range against the region instead. `drivers/dax/super.c` already does exactly this, for the same reason:

```c
	/*
	 * The userspace address for the memory copy has already been validated
	 * via access_ok() in vfs_red, so use the 'no check' version to bypass
	 * the HARDENED_USERCOPY overhead.
	 */
	if (test_bit(DAXDEV_NOMC, &dax_dev->flags))
		return _copy_mc_to_iter(addr, bytes, i);
	return _copy_to_iter(addr, bytes, i);
```

This covers every backing uniformly (vmap, direct map, ioremap), needs no `struct page`, and costs two comparisons. An earlier revision of this patch resolved the source to its page and used `copy_page_to_iter()`; that worked but only where struct pages exist, which excluded the spawn-kernel `ioremap` case, and left `vmalloc_to_page()` at 8.7% of the profile.

Since `_copy_to_iter()` no longer bounds-checks on our behalf, this also clamps the base image run in `daxfs_base_file_data()` against the mapped region. It previously validated only the start offset while the caller copied `*out_len` bytes from the returned pointer, so a truncated or malformed image could read past the end of the mapping.

The region check is a `WARN_ON_ONCE`, so a violation is loud rather than silent. It did not fire during any of the testing below.

## Results

40 CPU host, 125 GiB RAM, 12 GiB dma-buf region from the system heap, 2 GiB shared file, `direct=0 fallocate=none`, tmpfs at the same size for reference. MiB/s.

psync 4k random read, scaling:

| jobs | before | after | tmpfs |
|---:|---:|---:|---:|
| 1 | 3600 | **4376** | 3886 |
| 2 | 2903 | **6949** | 6044 |
| 4 | 2965 | **13161** | 10810 |
| 8 | 2763 | **21680** | 19450 |
| 16 | 3911 | **25259** | 23869 |

Full matrix:

| engine | pattern | jobs | before | after | tmpfs |
|---|---|---:|---:|---:|---:|
| psync | randread 4k | 1 | 3567 | **4712** | 4082 |
| psync | randread 4k | 8 | 2826 | **20887** | 18691 |
| psync | randwrite 4k | 1 | 2486 | **2983** | 2749 |
| psync | randwrite 4k | 8 | 2649 | **9323** | 2066 |
| psync | read seq 1m | 1 | 7470 | 7455 | 8016 |
| psync | write seq 1m | 1 | 3653 | **5019** | 4020 |
| mmap | randread 4k | 8 | 23753 | 24643 | 23251 |
| mmap | randwrite 4k | 8 | 9918 | 9857 | 10445 |

Mean 8-job read latency drops from 10.83 us to 1.28 us, p99 from 43.8 us to 2.7 us. On a 64 MiB file that fits in cache, 8-job read goes from 3977 to 37493 MiB/s.

The mmap rows are unchanged by design: that path maps PFNs into userspace and never calls `copy_to_iter()`.

After the fix the profile is all useful work:

```
   59.56%  _copy_to_iter
   13.09%  xas_load            (per-inode overlay page cache)
    5.33%  __vdso_clock_gettime
```

No lock symbol appears above 1.5%, and `vmalloc_to_page` is gone entirely.

## Testing

- 512 MiB random payload written and read back, md5 matches.
- Unaligned and page-straddling reads verified byte-for-byte against the source at offsets 0, 1, 4093, 4095, 4096, 65535 and EOF-3, with lengths spanning page boundaries.
- Full fio matrix (10 configurations, psync and mmap, 1 and 8 jobs) completed with no errors, no `WARN`, and no kernel warnings in `dmesg`.
- Single-threaded read measured over 3 repeats to separate the improvement from run-to-run noise.
- Only tested on the dma-buf backing; the `phys=` and spawn-kernel paths are covered by the same code path but were not exercised on hardware.

## Note for mainline

The `find_vmap_area()` behaviour is arguably an mm issue rather than a daxfs one: any large vmalloc region that userspace reads through degrades to an O(`nr_vmap_nodes`) locked scan, and it worsens with core count. Worth checking against current mainline.

Real persistent memory would also want `_copy_mc_to_iter()` for machine-check recovery, the way the DAX layer selects it via `DAXDEV_NOMC`. Not needed for the dma-buf and shared-DRAM backings today.
