### PR TITLE
daxfs: Discard overlay data on truncate

### DIFF
--- a/daxfs/file.c
+++ b/daxfs/file.c
@@ -471,6 +471,37 @@ static ssize_t daxfs_write_iter(struct kiocb *iocb, struct iov_iter *from)
 	return total;
 }
 
+/*
+ * Discard overlay data from @from up to the old end of file @to.
+ *
+ * The pages are zeroed rather than unmapped and freed. Freeing them would
+ * mean deleting keys from the open-addressed overlay hash, which needs
+ * tombstones it has no state bit for, and for an inode with base image data
+ * behind it dropping the overlay page would re-expose the base contents
+ * instead of the zeros POSIX requires. Zeroing is correct for both cases and
+ * leaves the pages ready to be reused if the file is extended again.
+ */
+static void daxfs_truncate_overlay(struct daxfs_info *info,
+				   struct inode *inode, loff_t from, loff_t to)
+{
+	u64 pgoff = from >> PAGE_SHIFT;
+	u32 intra = from & (PAGE_SIZE - 1);
+	void *page;
+
+	if (intra) {
+		page = daxfs_overlay_get_page_cached(info, inode, pgoff);
+		if (page)
+			memset(page + intra, 0, PAGE_SIZE - intra);
+		pgoff++;
+	}
+
+	for (; ((loff_t)pgoff << PAGE_SHIFT) < to; pgoff++) {
+		page = daxfs_overlay_get_page_cached(info, inode, pgoff);
+		if (page)
+			memset(page, 0, PAGE_SIZE);
+	}
+}
+
 static int daxfs_setattr(struct mnt_idmap *idmap, struct dentry *dentry,
 			 struct iattr *attr)
 {
@@ -478,6 +509,7 @@ static int daxfs_setattr(struct mnt_idmap *idmap, struct dentry *dentry,
 	struct daxfs_info *info = DAXFS_SB(inode->i_sb);
 	struct daxfs_ovl_inode_entry ie;
 	struct daxfs_ovl_inode_entry *existing;
+	loff_t old_size;
 	int ret;
 
 	if (!info->overlay)
@@ -488,12 +520,24 @@ static int daxfs_setattr(struct mnt_idmap *idmap, struct dentry *dentry,
 		return ret;
 
 	/*
+	 * Capture the old size before anything overwrites it. Another host may
+	 * have extended the file past our cached i_size, and those pages need
+	 * discarding too.
+	 */
+	old_size = i_size_read(inode);
+
+	/*
 	 * If overlay inode exists, update individual fields in-place.
 	 * Each WRITE_ONCE is atomic for its field width, so concurrent
 	 * setattr calls touching different fields won't clobber each other.
 	 */
 	existing = daxfs_overlay_get_inode(info, inode->i_ino);
 	if (existing) {
+		loff_t ovl_size = le64_to_cpu(READ_ONCE(existing->size));
+
+		if (ovl_size > old_size)
+			old_size = ovl_size;
+
 		if (attr->ia_valid & ATTR_SIZE)
 			WRITE_ONCE(existing->size, cpu_to_le64(attr->ia_size));
 		if (attr->ia_valid & ATTR_MODE)
@@ -534,6 +578,11 @@ static int daxfs_setattr(struct mnt_idmap *idmap, struct dentry *dentry,
 	if (attr->ia_valid & ATTR_SIZE) {
 		truncate_setsize(inode, attr->ia_size);
 		daxfs_update_blocks(inode);
+
+		/* After i_size shrinks, so readers cannot see the stale tail */
+		if (attr->ia_size < old_size)
+			daxfs_truncate_overlay(info, inode, attr->ia_size,
+					       old_size);
 	}
 
 	setattr_copy(idmap, inode, attr);

--- a/tests/test_overlay.sh
+++ b/tests/test_overlay.sh
@@ -556,6 +556,44 @@ test_overlay_truncate() {
     pass "Truncate via overlay"
 }
 
+test_overlay_truncate_zeroes() {
+    run_test "Truncate discards data (no stale bytes on re-extend)"
+
+    local f="$MNT/trunc-stale.bin"
+
+    printf 'AAAAAAAAAAAAAAAA' > "$f" \
+        || { fail "Truncate zeroes" "Failed to create file"; return; }
+    truncate -s 0 "$f" \
+        || { fail "Truncate zeroes" "Failed to truncate"; return; }
+
+    # Re-extend past the old data. Everything below the write must read zero.
+    dd if=/dev/zero of="$f" bs=1 count=1 seek=65536 conv=notrunc status=none \
+        || { fail "Truncate zeroes" "Failed to re-extend"; return; }
+
+    local head
+    head=$(dd if="$f" bs=16 count=1 status=none | tr -d '\0')
+    if [ -n "$head" ]; then
+        fail "Truncate zeroes" "stale data after truncate: '$head'"
+        return
+    fi
+
+    # Same again for a partial page: the tail of the surviving page must go.
+    printf 'BBBBBBBBBBBBBBBB' > "$f"
+    truncate -s 4 "$f"
+    dd if=/dev/zero of="$f" bs=1 count=1 seek=4096 conv=notrunc status=none \
+        || { fail "Truncate zeroes" "Failed to re-extend (partial)"; return; }
+
+    local tail
+    tail=$(dd if="$f" bs=1 skip=4 count=12 status=none | tr -d '\0')
+    if [ -n "$tail" ]; then
+        fail "Truncate zeroes" "stale tail in partial page: '$tail'"
+        return
+    fi
+
+    rm -f "$f"
+    pass "Truncate discards data (no stale bytes on re-extend)"
+}
+
 #
 # Empty mode tests
 #
@@ -815,6 +853,7 @@ main() {
     test_overlay_symlink
     test_overlay_rename
     test_overlay_truncate
+    test_overlay_truncate_zeroes
 
     # Empty mode tests
     setup_empty


### PR DESCRIPTION
## Problem

Truncating a file left its overlay pages in place. Nothing erased them from the per-inode xarray or the DAX overlay hash, so extending the file again handed back the old contents instead of zeros.

Reproduced on a 40 CPU host, empty-mode dma-buf mount:

```
write 8192 bytes of 'A'
truncate to 0
write 1 byte at offset 65536
read offset 0     ->  b'AAAAAAAAAAAAAAAA'      (must be zeros)
```

The partial-page case fails the same way: truncate to 4 bytes and the remaining 4092 bytes of that page come back on re-extend.

POSIX requires the extended range to read as zeros. For a filesystem built around a shared base image with per-container overlays, data surviving a truncate is a disclosure bug rather than only a correctness one.

`daxfs_setattr()` called `truncate_setsize()` and updated `oie->size`, and that was all. `overlay_pool_free()` is never reached from the DATA path except for the publish-race case at `overlay.c:599`, so the pages were also leaked.

## Fix

Zero the overlay pages from the new size up to the old end of file, including the tail of a partial page at the boundary.

The pages are kept mapped rather than freed. Two reasons:

- Freeing means deleting keys from the open-addressed overlay hash. `DAXFS_OVL_STATE()` is a single bit with the key in the remaining 63, so there is no room for a tombstone state, and marking a bucket `FREE` would truncate the probe chain for every key that probed past it. Adding tombstones is a format change.
- For an inode with base image data behind it, removing the overlay page would re-expose the *base* contents rather than zeros. Zeroing is correct for both the overlay-only and base-backed cases.

Keeping the pages also leaves them ready for a re-extend, which is the common truncate-then-rewrite pattern. The pool space is not reclaimed, which matches the existing behaviour for every other data page.

The old size is captured before any field is overwritten, and taken as the larger of the cached `i_size` and the overlay entry's size, so pages another host wrote past our stale `i_size` are discarded too.

Zeroing runs after `truncate_setsize()`, so a concurrent reader sees the smaller `i_size` before the tail starts changing rather than after.

## Testing

New regression test in `tests/test_overlay.sh` covering three cases: the full-page case, the partial-page tail, and that data *below* the truncation point survives (so the test cannot pass by zeroing too much).

Verified it actually catches the bug rather than passing vacuously:

```
without the fix:   FAIL: Truncate zeroes
                         stale data after truncate: 'AAAAAAAAAAAAAAAA'
                   Tests run: 21, passed: 20, failed: 1

with the fix:      PASS: Truncate discards data (no stale bytes on re-extend)
                   Tests run: 21, passed: 21, failed: 0
```

Also re-checked after the change: 256 MiB random payload round-trips with a matching md5, and no new `dmesg` warnings.

## Cost

Truncating to zero now memsets the overlay allocation, so a 2 GiB file costs a 2 GiB memset, roughly 0.2 s at 10 GB/s. That is inherent to zeroing in place rather than freeing; reclaiming the pages instead would need the tombstone format change described above.
